### PR TITLE
#8 그룹 중단 구현하기

### DIFF
--- a/remind/void_method_exception_테스트.md
+++ b/remind/void_method_exception_테스트.md
@@ -1,0 +1,16 @@
+Validation을 하며 Exception을 던지는 응답이 void인 메서드를 테스트하는 경우 toThrow, thThrowError로 테스트가 안된다.
+
+이런 경우에는 다음과 같이 진행하면 된다.
+```typescript
+it('수행요일이_아닌_경우_테스트', () => {
+    const date = new Date('2022-01-02T06:00:00.000');
+    try {
+      myGroupService['checkDayIsInclude'](date, [Week.WED]);
+    } catch (err) {
+      expect(err).toEqual(new BadRequestException(INVALID_DATE));
+    }
+  });
+```
+위 처럼 try catch로 감싼뒤 catch되는 error가 예상하는 exception가 같은지 비교하면 된다.  
+똑같은 Exception이라도 Message가 다르면 toEqual에 의해 실패처리가 된다.  
+이유는 Exception을 비교하는 것이 아니라 객체를 비교하듯이 비교하기 때문이다.

--- a/remind/void_method_exception_테스트.md
+++ b/remind/void_method_exception_테스트.md
@@ -14,3 +14,7 @@ it('수행요일이_아닌_경우_테스트', () => {
 위 처럼 try catch로 감싼뒤 catch되는 error가 예상하는 exception가 같은지 비교하면 된다.  
 똑같은 Exception이라도 Message가 다르면 toEqual에 의해 실패처리가 된다.  
 이유는 Exception을 비교하는 것이 아니라 객체를 비교하듯이 비교하기 때문이다.
+
+---
+참고자료  
+https://hdevstudy.tistory.com/133

--- a/src/common/response/content/message.my-group.ts
+++ b/src/common/response/content/message.my-group.ts
@@ -12,3 +12,4 @@ export const INVALID_DATE = '수행하는 날이 아닙니다.';
 export const INVALID_IMAGE = '이미지가 비어있습니다.';
 export const MY_GROUP_STATUS_OK =
   '나의 그룹 오늘 수행 현황을 정상적으로 조회하였습니다.';
+export const MY_GROUP_DELETE_OK = '정상적으로 나의 그룹이 삭제되었습니다.';

--- a/src/entities/group.ts
+++ b/src/entities/group.ts
@@ -48,6 +48,12 @@ export class Group {
   @Column({ type: 'int' })
   todayCnt: number;
 
+  @Column({ type: 'varchar' })
+  startTime: string;
+
+  @Column({ type: 'varchar' })
+  endTime: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/entities/group.ts
+++ b/src/entities/group.ts
@@ -9,6 +9,8 @@ import {
 import { MyGroup } from './my.group';
 import { Image } from './image';
 import { Category } from '../common/enum/category';
+import { BadRequestException } from '@nestjs/common';
+import { INVALID_TIME } from '../common/response/content/message.my-group';
 
 @Entity()
 export class Group {
@@ -59,4 +61,17 @@ export class Group {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  public checkTime(): void {
+    const dateTime = new Date().getTime();
+    const startHour = parseInt(this.startTime.slice(0, 2));
+    const endHour = parseInt(this.startTime.slice(0, 2));
+    const startMin = parseInt(this.startTime.slice(3, 5));
+    const endMin = parseInt(this.startTime.slice(3, 5));
+    const startTime = new Date().setHours(startHour, startMin, 0, 0);
+    const endTime = new Date().setHours(endHour, endMin, 0, 0);
+    if (!(startTime <= dateTime && dateTime <= endTime)) {
+      throw new BadRequestException(INVALID_TIME);
+    }
+  }
 }

--- a/src/entities/image.ts
+++ b/src/entities/image.ts
@@ -19,7 +19,10 @@ export class Image {
   @JoinColumn([{ name: 'group_id', referencedColumnName: 'groupId' }])
   group: Group;
 
-  @ManyToOne(() => MyGroup, (myGroup) => myGroup.imageList, { primary: true })
+  @ManyToOne(() => MyGroup, (myGroup) => myGroup.imageList, {
+    primary: true,
+    onDelete: 'CASCADE',
+  })
   @JoinColumn([{ name: 'my_group_id', referencedColumnName: 'myGroupId' }])
   myGroup: MyGroup;
 

--- a/src/entities/my.group.ts
+++ b/src/entities/my.group.ts
@@ -20,14 +20,10 @@ export class MyGroup {
   @Column({ type: 'bigint', name: 'user_id' })
   userId: number;
 
-  @OneToMany(() => Image, (imageList) => imageList.myGroup, {
-    onDelete: 'CASCADE',
-  })
+  @OneToMany(() => Image, (imageList) => imageList.myGroup)
   imageList: Image[];
 
-  @OneToMany(() => MyGroupWeek, (weekList) => weekList.myGroup, {
-    onDelete: 'CASCADE',
-  })
+  @OneToMany(() => MyGroupWeek, (weekList) => weekList.myGroup)
   weekList: MyGroupWeek[];
 
   @ManyToOne(() => Group, (group) => group.myGroupList, { cascade: ['update'] })

--- a/src/entities/my.group.week.ts
+++ b/src/entities/my.group.week.ts
@@ -9,7 +9,10 @@ export class MyGroupWeek {
     this.week = week;
   }
 
-  @ManyToOne(() => MyGroup, (myGroup) => myGroup.weekList, { primary: true })
+  @ManyToOne(() => MyGroup, (myGroup) => myGroup.weekList, {
+    primary: true,
+    onDelete: 'CASCADE',
+  })
   @JoinColumn([{ name: 'my_group_id', referencedColumnName: 'myGroupId' }])
   myGroup: MyGroup;
 

--- a/src/my-group/controller/my-group.controller.ts
+++ b/src/my-group/controller/my-group.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpStatus,
   Post,
@@ -20,6 +21,7 @@ import { ResponseEntity } from '../../common/response/response.entity';
 import {
   DONE_MY_GROUP_OK,
   MY_GROUP_CREATE_OK,
+  MY_GROUP_DELETE_OK,
   MY_GROUP_OK,
   MY_GROUP_STATUS_OK,
 } from '../../common/response/content/message.my-group';
@@ -30,6 +32,16 @@ import { EntityManager } from '../../common/decorators/entity.manager.decorator'
 @Controller('/api/v1/my-group')
 export class MyGroupController {
   constructor(private readonly myGroupService: MyGroupService) {}
+
+  @Delete('')
+  // Todo -> UseGuard(...)
+  public async deleteMyGroup(
+    @Query('myGroupId') myGroupId: number,
+    @Query('userId') userId: number,
+  ): Promise<ResponseMessage> {
+    await this.myGroupService.deleteMyGroup(myGroupId, userId);
+    return ResponseEntity.OK(MY_GROUP_DELETE_OK);
+  }
 
   @Get('/day/status')
   // Todo -> UseGuard(...)

--- a/src/my-group/service/my-group.service.ts
+++ b/src/my-group/service/my-group.service.ts
@@ -21,7 +21,6 @@ import {
   INVALID_DATE,
   INVALID_IMAGE,
   INVALID_MY_GROUP_ID,
-  INVALID_TIME,
   IS_DONE,
   MY_GROUP_NOT_FOUND,
   NOT_EXIST_GROUP,
@@ -189,17 +188,10 @@ export class MyGroupService {
     const weekList = myGroup.weekList.map((myWeek) => {
       return Number(Week[myWeek.week]);
     });
-    this.checkIsValidTime(date);
+    myGroup.group.checkTime();
     this.checkDayIsInclude(date, weekList);
     this.checkIsDone(myGroup);
     this.checkFileIsNotNull(file);
-  }
-
-  private checkIsValidTime(date: Date): void {
-    const hour = date.getHours();
-    if (!(hour <= 8 && hour >= 5)) {
-      throw new BadRequestException(INVALID_TIME);
-    }
   }
 
   private checkDayIsInclude(date: Date, weekList: Week[]): void {

--- a/test/service/my-group.service.spec.ts
+++ b/test/service/my-group.service.spec.ts
@@ -17,6 +17,12 @@ import {
 } from '../template/my.group.template';
 import { MyGroup } from '../../src/entities/my.group';
 import { Week } from '../../src/common/enum/week';
+import {
+  INVALID_DATE,
+  INVALID_IMAGE,
+  INVALID_TIME,
+  IS_DONE,
+} from '../../src/common/response/content/message.my-group';
 
 describe('MyGroupService', () => {
   let myGroupService: MyGroupService;
@@ -109,36 +115,37 @@ describe('MyGroupService', () => {
   });
 
   it('수행시간이_아닌_경우_테스트', () => {
-    jest.useFakeTimers('modern');
-    jest.setSystemTime(new Date('2022-01-02T10:20:30Z').getTime());
-    expect(myGroupService['checkValid'](myGroup2, mockFile)).rejects.toThrow(
-      BadRequestException,
-    );
+    const date = new Date('2022-01-02T15:00:00.000');
+    try {
+      myGroupService['checkIsValidTime'](date);
+    } catch (err) {
+      expect(err).toEqual(new BadRequestException(INVALID_TIME));
+    }
   });
 
   it('수행요일이_아닌_경우_테스트', () => {
-    jest.useFakeTimers('modern');
-    jest.setSystemTime(new Date('2022-01-02T06:00:30Z').getTime());
-    myGroup2.weekList[0].week = Week.WED;
-    expect(myGroupService['checkValid'](myGroup2, mockFile)).rejects.toThrow(
-      BadRequestException,
-    );
+    const date = new Date('2022-01-02T06:00:00.000');
+    try {
+      myGroupService['checkDayIsInclude'](date, [Week.WED]);
+    } catch (err) {
+      expect(err).toEqual(new BadRequestException(INVALID_DATE));
+    }
   });
 
   it('이미_수행한_경우_테스트', () => {
-    jest.useFakeTimers('modern');
-    jest.setSystemTime(new Date('2022-01-02T06:00:30Z').getTime());
-    myGroup2.isDone = true;
-    expect(myGroupService['checkValid'](myGroup2, mockFile)).rejects.toThrow(
-      BadRequestException,
-    );
+    try {
+      myGroup2.isDone = true;
+      myGroupService['checkIsDone'](myGroup2);
+    } catch (err) {
+      expect(err).toEqual(new BadRequestException(IS_DONE));
+    }
   });
 
   it('이미지가_없는_경우_테스트', () => {
-    jest.useFakeTimers('modern');
-    jest.setSystemTime(new Date('2022-01-02T06:00:30Z').getTime());
-    expect(myGroupService['checkValid'](myGroup2, null)).rejects.toThrow(
-      BadRequestException,
-    );
+    try {
+      myGroupService['checkFileIsNotNull'](mockFile);
+    } catch (err) {
+      expect(err).toEqual(new BadRequestException(INVALID_IMAGE));
+    }
   });
 });

--- a/test/service/my-group.service.spec.ts
+++ b/test/service/my-group.service.spec.ts
@@ -117,9 +117,12 @@ describe('MyGroupService', () => {
   });
 
   it('수행시간이_아닌_경우_테스트', () => {
-    const date = new Date('2022-01-02T15:00:00.000');
+    const date = new Date();
+    date.setHours(7, 19, 0, 0);
+    jest.useFakeTimers('modern');
+    jest.setSystemTime(date.getTime());
     try {
-      myGroupService['checkIsValidTime'](date);
+      myGroup2.group.checkTime();
     } catch (err) {
       expect(err).toEqual(new BadRequestException(INVALID_TIME));
     }

--- a/test/service/my-group.service.spec.ts
+++ b/test/service/my-group.service.spec.ts
@@ -20,8 +20,10 @@ import { Week } from '../../src/common/enum/week';
 import {
   INVALID_DATE,
   INVALID_IMAGE,
+  INVALID_MY_GROUP_ID,
   INVALID_TIME,
   IS_DONE,
+  MY_GROUP_NOT_FOUND,
 } from '../../src/common/response/content/message.my-group';
 
 describe('MyGroupService', () => {
@@ -146,6 +148,22 @@ describe('MyGroupService', () => {
       myGroupService['checkFileIsNotNull'](mockFile);
     } catch (err) {
       expect(err).toEqual(new BadRequestException(INVALID_IMAGE));
+    }
+  });
+
+  it('나의그룹_없는_경우_테스트', () => {
+    try {
+      myGroupService['checkIsNotNull'](null);
+    } catch (err) {
+      expect(err).toEqual(new BadRequestException(MY_GROUP_NOT_FOUND));
+    }
+  });
+
+  it('나의그룹이_아닌_경우_테스트', () => {
+    try {
+      myGroupService['checkIsMine'](myGroup2, 2); // myGroup2.userId = 4
+    } catch (err) {
+      expect(err).toEqual(new BadRequestException(INVALID_MY_GROUP_ID));
     }
   });
 });

--- a/test/template/group.template.ts
+++ b/test/template/group.template.ts
@@ -7,6 +7,8 @@ group1.title = '러닝하기';
 group1.category = 3;
 group2.groupId = 2;
 group2.category = 4;
+group2.startTime = '07:20';
+group2.endTime = '07:30';
 
 export const groupAllList: Group[] = [group1, group2];
 export const groupListByHealth: Group[] = [group1];


### PR DESCRIPTION
그룹 중단 구현하기
기존 myGroupService 로직 세분화 및 테스트 케이스 수정

Request
`http://localhost:3000/api/v1/my-group?myGroupId=102&userId=36 (DELETE)`

Response
```json
{
    "status": 200,
    "message": "정상적으로 나의 그룹이 삭제되었습니다."
}
```

삭제 조건
- 나의 그룹이 존재
- 나의 그룹의 userId는 요청 받은 userId와 같음

삭제는 Image, MyGroupWeek가 함께 삭제됩니다.