### PR TITLE
#13 진행중인 내 그룹 isDone 초기화 및 종료 된 내 그룹 계산 로직

### DIFF
--- a/src/common/response/content/message.group.ts
+++ b/src/common/response/content/message.group.ts
@@ -1,3 +1,5 @@
 export const GROUP_OK = '그룹 조회를 정상적으로 수행하였습니다.';
 export const GROUP_NOT_FOUND = '그룹이 존재하지 않습니다.';
 export const GROUP_IMAGE_OK = '그룹의 이미지를 정상적으로 조회하였습니다.';
+export const GROUP_AVG_RATE_AND_TO_DAY_CNT_OK =
+  '그룹 평균 수행률 계산 및 ToDayCnt 초기화 성공하였습니다.';

--- a/src/common/response/content/message.my-group.ts
+++ b/src/common/response/content/message.my-group.ts
@@ -17,3 +17,5 @@ export const MY_GROUP_DETAIL_OK =
   '나의 그룹 디페일 페이지를 정상적으로 조회하였습니다.';
 export const MY_IMAGE_LIST_OK = '정상적으로 나의 이미지를 조회하였습니다.';
 export const MY_GROUP_IS_DONE_INIT_OK = 'isDone 초기화 성공하였습니다.';
+export const MY_GROUP_FINISH_PROCESS_OK =
+  '종료 된 나의 그룹을 정상적으로 처리하였습니다.';

--- a/src/common/response/content/message.my-group.ts
+++ b/src/common/response/content/message.my-group.ts
@@ -16,3 +16,4 @@ export const MY_GROUP_DELETE_OK = '정상적으로 나의 그룹이 삭제되었
 export const MY_GROUP_DETAIL_OK =
   '나의 그룹 디페일 페이지를 정상적으로 조회하였습니다.';
 export const MY_IMAGE_LIST_OK = '정상적으로 나의 이미지를 조회하였습니다.';
+export const MY_GROUP_IS_DONE_INIT_OK = 'isDone 초기화 성공하였습니다.';

--- a/src/entities/group.ts
+++ b/src/entities/group.ts
@@ -80,4 +80,12 @@ export class Group {
       throw new BadRequestException(INVALID_TIME);
     }
   }
+
+  public calAvgRate(sum, cnt) {
+    this.avgRate = Math.round(sum / cnt);
+  }
+
+  public initToDayCnt() {
+    this.todayCnt = 0;
+  }
 }

--- a/src/entities/group.ts
+++ b/src/entities/group.ts
@@ -56,6 +56,12 @@ export class Group {
   @Column({ type: 'varchar' })
   endTime: string;
 
+  @Column({ type: 'int' })
+  endGroupTotalRate: number;
+
+  @Column({ type: 'int' })
+  endGroupTotalCnt: number;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/entities/my.group.ts
+++ b/src/entities/my.group.ts
@@ -66,4 +66,8 @@ export class MyGroup {
   public updateIsDone(): void {
     this.isDone = false;
   }
+
+  public updateIsStatus(): void {
+    this.status = false;
+  }
 }

--- a/src/entities/my.group.ts
+++ b/src/entities/my.group.ts
@@ -62,4 +62,8 @@ export class MyGroup {
     this.successCnt += 1;
     this.group.todayCnt += 1;
   }
+
+  public updateIsDone(): void {
+    this.isDone = false;
+  }
 }

--- a/src/entities/my.group.ts
+++ b/src/entities/my.group.ts
@@ -31,10 +31,10 @@ export class MyGroup {
   group: Group;
 
   @Column({ type: 'int' })
-  successCnt;
+  successCnt: number;
 
   @Column({ type: 'int' })
-  totalDateCnt;
+  totalDateCnt: number;
 
   @CreateDateColumn()
   createdAt: Date;
@@ -49,13 +49,13 @@ export class MyGroup {
   alarmTime: string;
 
   @Column({ type: 'int' })
-  rate;
+  rate: number;
 
   @Column({ type: 'boolean' })
-  status;
+  status: boolean;
 
   @Column({ type: 'boolean' })
-  isDone;
+  isDone: boolean;
 
   public doneDayMyGroup(): void {
     this.isDone = true;

--- a/src/group/controller/group.controller.ts
+++ b/src/group/controller/group.controller.ts
@@ -1,8 +1,16 @@
-import { Controller, Get, HttpStatus, Param, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpStatus,
+  Param,
+  Query,
+} from '@nestjs/common';
 import { GroupService } from '../service/group.service';
 import { GroupDetail, GroupResponseDto } from '../dto/group.dto';
 import { ResponseEntity } from '../../common/response/response.entity';
 import {
+  GROUP_AVG_RATE_AND_TO_DAY_CNT_OK,
   GROUP_IMAGE_OK,
   GROUP_OK,
 } from '../../common/response/content/message.group';
@@ -11,6 +19,12 @@ import { ResponseMessage } from '../../common/response/response.message';
 @Controller('/api/v1/group')
 export class GroupController {
   constructor(private groupService: GroupService) {}
+
+  @Get('/scheduling/rate')
+  public async calAvgRateAndInitToDayCnt(@Body('groupIds') groupIds: number[]) {
+    await this.groupService.calAvgRateAndInitToDayCnt(groupIds);
+    return ResponseEntity.OK(GROUP_AVG_RATE_AND_TO_DAY_CNT_OK);
+  }
 
   @Get('/image')
   public async getImageList(

--- a/src/group/group.module.ts
+++ b/src/group/group.module.ts
@@ -1,12 +1,16 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { GroupController } from './controller/group.controller';
 import { GroupService } from './service/group.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { GroupRepository } from './repository/group.repository';
 import { ImageRepository } from '../image/image.repository';
+import { MyGroupModule } from '../my-group/my-group.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([GroupRepository, ImageRepository])],
+  imports: [
+    TypeOrmModule.forFeature([GroupRepository, ImageRepository]),
+    forwardRef(() => MyGroupModule),
+  ],
   controllers: [GroupController],
   providers: [GroupService],
   exports: [GroupService],

--- a/src/my-group/controller/my-group.controller.ts
+++ b/src/my-group/controller/my-group.controller.ts
@@ -24,6 +24,7 @@ import {
   MY_GROUP_CREATE_OK,
   MY_GROUP_DELETE_OK,
   MY_GROUP_DETAIL_OK,
+  MY_GROUP_FINISH_PROCESS_OK,
   MY_GROUP_IS_DONE_INIT_OK,
   MY_GROUP_OK,
   MY_GROUP_STATUS_OK,
@@ -36,6 +37,19 @@ import { EntityManager } from '../../common/decorators/entity.manager.decorator'
 @Controller('/api/v1/my-group')
 export class MyGroupController {
   constructor(private readonly myGroupService: MyGroupService) {}
+
+  @Post('/scheduling/is-status')
+  @UseInterceptors(TransactionInterceptor)
+  public async updateStatusByFinishedMyGroupIds(
+    @Body('myGroupIds') myGroupIds: number[],
+    @EntityManager() manager,
+  ) {
+    await this.myGroupService.updateStatusByFinishedMyGroupIds(
+      myGroupIds,
+      manager,
+    );
+    return ResponseEntity.OK(MY_GROUP_FINISH_PROCESS_OK);
+  }
 
   @Post('/scheduling/is-done')
   public async updateIsDoneByMyGroupIds(

--- a/src/my-group/controller/my-group.controller.ts
+++ b/src/my-group/controller/my-group.controller.ts
@@ -24,6 +24,7 @@ import {
   MY_GROUP_CREATE_OK,
   MY_GROUP_DELETE_OK,
   MY_GROUP_DETAIL_OK,
+  MY_GROUP_IS_DONE_INIT_OK,
   MY_GROUP_OK,
   MY_GROUP_STATUS_OK,
   MY_IMAGE_LIST_OK,
@@ -35,6 +36,14 @@ import { EntityManager } from '../../common/decorators/entity.manager.decorator'
 @Controller('/api/v1/my-group')
 export class MyGroupController {
   constructor(private readonly myGroupService: MyGroupService) {}
+
+  @Post('/scheduling/is-done')
+  public async updateIsDoneByMyGroupIds(
+    @Body('myGroupIds') myGroupIds: number[],
+  ) {
+    await this.myGroupService.updateIsDoneByMyGroupIds(myGroupIds);
+    return ResponseEntity.OK(MY_GROUP_IS_DONE_INIT_OK);
+  }
 
   @Get('/image')
   public async getImageList(

--- a/src/my-group/my-group.module.ts
+++ b/src/my-group/my-group.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { MyGroupController } from './controller/my-group.controller';
 import { MyGroupService } from './service/my-group.service';
 import { GroupModule } from '../group/group.module';
@@ -10,9 +10,10 @@ import { ImageRepository } from '../image/image.repository';
 @Module({
   imports: [
     TypeOrmModule.forFeature([MyGroupRepository, MyGroupWeek, ImageRepository]),
-    GroupModule,
+    forwardRef(() => GroupModule),
   ],
   controllers: [MyGroupController],
   providers: [MyGroupService],
+  exports: [MyGroupService],
 })
 export class MyGroupModule {}

--- a/src/my-group/repository/my-group.repository.ts
+++ b/src/my-group/repository/my-group.repository.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, Repository } from 'typeorm';
+import { EntityRepository, getRepository, Repository } from 'typeorm';
 import { MyGroup } from '../../entities/my.group';
 import { MyGroupDoneAndAllCnt } from '../dto/my.group.dto';
 
@@ -60,5 +60,16 @@ export class MyGroupRepository extends Repository<MyGroup> {
         myGroupId: myGroupId,
       })
       .getOne();
+  }
+
+  public async getRateSunAndCntByStatusIsTrue() {
+    return getRepository(MyGroup)
+      .createQueryBuilder('mg')
+      .select('mg.group.groupId', 'groupId')
+      .addSelect('SUM(mg.rate)', 'sum')
+      .addSelect('COUNT(mg.myGroupId)', 'cnt')
+      .where('mg.status = true')
+      .groupBy('mg.group.groupId')
+      .getRawMany();
   }
 }

--- a/src/my-group/service/my-group.service.ts
+++ b/src/my-group/service/my-group.service.ts
@@ -1,5 +1,7 @@
 import {
   BadRequestException,
+  forwardRef,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -38,6 +40,7 @@ export class MyGroupService {
     private myGroupRepository: MyGroupRepository,
     private imageRepository: ImageRepository,
     private connection: Connection,
+    @Inject(forwardRef(() => GroupService))
     private groupService: GroupService,
     @InjectRepository(MyGroupWeek)
     private myGroupWeekRepository: Repository<MyGroupWeek>,
@@ -305,5 +308,9 @@ export class MyGroupService {
       groupMap.get(myGroup.group.groupId).endGroupTotalRate += myGroup.rate;
     });
     return groupMap;
+  }
+
+  public async getRateSunAndCntByStatusIsTrue() {
+    return await this.myGroupRepository.getRateSunAndCntByStatusIsTrue();
   }
 }

--- a/src/my-group/service/my-group.service.ts
+++ b/src/my-group/service/my-group.service.ts
@@ -252,4 +252,10 @@ export class MyGroupService {
     image.url = file.originalname + new Date().getMilliseconds();
     return image;
   }
+
+  async updateIsDoneByMyGroupIds(myGroupIds: number[]) {
+    const myGroupList = await this.myGroupRepository.findByIds(myGroupIds);
+    myGroupList.forEach((myGroup) => myGroup.updateIsDone());
+    await this.myGroupRepository.save(myGroupList);
+  }
 }

--- a/src/my-group/service/my-group.service.ts
+++ b/src/my-group/service/my-group.service.ts
@@ -276,6 +276,7 @@ export class MyGroupService {
     myGroupList.forEach((myGroup) => myGroup.updateIsStatus());
     groupMemberCntMap.forEach((memberCnt, key) => {
       groupMap.get(key).memberCnt -= memberCnt;
+      groupMap.get(key).endGroupTotalCnt += memberCnt;
     });
     await manager.getRepository(MyGroup).save(myGroupList);
     await manager.getRepository(Group).save(groupList);
@@ -299,6 +300,9 @@ export class MyGroupService {
     const groupMap = new Map<number, Group>();
     myGroupList.forEach((myGroup) => {
       groupMap.set(myGroup.group.groupId, myGroup.group);
+    });
+    myGroupList.forEach((myGroup) => {
+      groupMap.get(myGroup.group.groupId).endGroupTotalRate += myGroup.rate;
     });
     return groupMap;
   }

--- a/src/my-group/service/my-group.service.ts
+++ b/src/my-group/service/my-group.service.ts
@@ -30,6 +30,7 @@ import { Image } from '../../entities/image';
 import { ImageRepository } from '../../image/image.repository';
 import { Order } from '../../common/enum/Order';
 import { ImageDto } from '../../image/image.dto';
+import { Group } from '../../entities/group';
 
 @Injectable()
 export class MyGroupService {
@@ -257,5 +258,48 @@ export class MyGroupService {
     const myGroupList = await this.myGroupRepository.findByIds(myGroupIds);
     myGroupList.forEach((myGroup) => myGroup.updateIsDone());
     await this.myGroupRepository.save(myGroupList);
+  }
+
+  async updateStatusByFinishedMyGroupIds(
+    myGroupIds: number[],
+    manager: EntityManager,
+  ) {
+    const myGroupList = await manager
+      .getRepository(MyGroup)
+      .findByIds(myGroupIds, {
+        relations: ['group'],
+      });
+    const groupList = [];
+    const groupMemberCntMap = this.initGroupMemberCntMap(myGroupList);
+    const groupMap = this.initGroupMap(myGroupList);
+    groupMap.forEach((group) => groupList.push(group));
+    myGroupList.forEach((myGroup) => myGroup.updateIsStatus());
+    groupMemberCntMap.forEach((memberCnt, key) => {
+      groupMap.get(key).memberCnt -= memberCnt;
+    });
+    await manager.getRepository(MyGroup).save(myGroupList);
+    await manager.getRepository(Group).save(groupList);
+  }
+
+  private initGroupMemberCntMap(myGroupList: MyGroup[]) {
+    const groupMemberCntMap = new Map<number, number>();
+    myGroupList.forEach((myGroup) => {
+      groupMemberCntMap.set(myGroup.group.groupId, 0);
+    });
+    myGroupList.forEach((myGroup) => {
+      groupMemberCntMap.set(
+        myGroup.group.groupId,
+        groupMemberCntMap.get(myGroup.group.groupId) + 1,
+      );
+    });
+    return groupMemberCntMap;
+  }
+
+  private initGroupMap(myGroupList: MyGroup[]) {
+    const groupMap = new Map<number, Group>();
+    myGroupList.forEach((myGroup) => {
+      groupMap.set(myGroup.group.groupId, myGroup.group);
+    });
+    return groupMap;
   }
 }


### PR DESCRIPTION
진행중인 내 그룹 isDone 초기화 및 종료 된 내 그룹 계산 로직
그룹 평균 달성률 계산 수행 로직 및 today_cnt 초기화 로직 구현

**#13**
- 매일 내 그룹 isDone(수행여부) 초기화
- 종료 된 내 그룹 처리
  - 그룹 참여자 수 -1
  - 나의 그룹 status -> false
  - 그룹의 끝난 그룹 평균 총합 및 끝난 그룹 총 개수 계산(+ myGroup Avg, Cnt+1)

**#6**
- 그룹 평균 달성률 계산 수행 로직
  - (그룹의 끝난 모든 수행률 합 + 진행중인 수행률 합) / (그룹의 끝난 모든 그룹 수 + 진행중인 그룹 수)
- today_cnt 초기화

#13, #6 외에 빼먹은 스케줄링 로직이 있다면 알려주세요!